### PR TITLE
UX: prevent logo from scaling disproportionately

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -8,6 +8,7 @@
   // when the sidebar is opened
   max-height: 100%;
   max-width: 100%;
+  object-fit: contain; // contains logo without squishing/stretching
 }
 
 #main-outlet-wrapper {


### PR DESCRIPTION
With certain logo sizes the logo was being stretched (depending on the browser width and zoom level). This avoids it! 