### PR TITLE
TEMP: override scrollIntoView to fix scroll issue

### DIFF
--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -1,0 +1,52 @@
+/* This is a temporary override that modifies line 46 to use "block:nearest"to
+avoid a problem with scrolling the main content */
+
+<script type="text/discourse-plugin" version="0.8">
+    const { cancel, schedule } = require("@ember/runloop");
+
+    api.modifyClass('component:chat-live-pane', {
+      pluginId: "full-width-component",
+
+      scrollToMessage(
+      messageId,
+      opts = { highlight: false, position: "start", autoExpand: false }
+    ) {
+      if (this._selfDeleted) {
+        return;
+      }
+
+      const message = this.args.channel.findMessage(messageId);
+      if (message?.deletedAt && opts.autoExpand) {
+        message.expanded = true;
+      }
+
+      schedule("afterRender", () => {
+        const messageEl = this._scrollerEl.querySelector(
+          `.chat-message-container[data-id='${messageId}']`
+        );
+
+        if (!messageEl || this._selfDeleted) {
+          return;
+        }
+
+        if (opts.highlight) {
+          message.highlighted = true;
+
+          discourseLater(() => {
+            if (this._selfDeleted) {
+              return;
+            }
+
+            message.highlighted = false;
+          }, 2000);
+        }
+
+        this.forceRendering(() => {
+          messageEl.scrollIntoView({
+            block: "nearest",
+          });
+        });
+      });
+    }
+  })
+</script>

--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -1,5 +1,5 @@
-/* This is a temporary override that modifies line 46 to use "block:nearest"to
-avoid a problem with scrolling the main content */
+<!--  This is a temporary override that modifies line 46 to use "block:nearest"to
+avoid a problem with scrolling the main content -->
 
 <script type="text/discourse-plugin" version="0.8">
     const { cancel, schedule } = require("@ember/runloop");


### PR DESCRIPTION
With some of the recent experimental chat features a new message being sent was causing the main content to scroll in addition to chat, this temporarily overrides `scrollIntoView` in core to avoid the issue for now. 