### PR TITLE
UX: adjust composer when chat drawer is resized

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -245,16 +245,20 @@ body.sidebar-animate {
 
 @mixin flatComposer {
   #reply-control {
+    border-left: 1px solid var(--primary-low);
+    border-right: 1px solid var(--primary-low);
     box-shadow: none;
+    min-width: 653px;
   }
 }
 
 @mixin drawerWidth {
   .chat-drawer {
-    max-width: 370px;
+    max-width: 638px;
     margin-left: 2em;
     .chat-drawer-container {
       border-top: none;
+      box-shadow: none;
     }
   }
 }
@@ -273,8 +277,13 @@ body.sidebar-animate {
 
 @if ($avoid_composer_overlap == "true") {
   :root {
-    --full-width-drawer-width: 385px;
-    --full-width-composer-max-width: 1478px;
+    --full-width-drawer-width: var(
+      --custom-drawer-width-composer-margin,
+      385px
+    );
+    --full-width-composer-max-width: calc(
+      100vw - var(--d-sidebar-width) - 15px
+    );
   }
 
   // sidebar only
@@ -289,6 +298,7 @@ body.sidebar-animate {
           max-width: var(--full-width-composer-max-width);
           margin-left: var(--d-sidebar-width);
           margin-right: auto;
+          transition: width 0.25s;
         }
       }
     }
@@ -300,15 +310,13 @@ body.sidebar-animate {
     .chat-drawer-active:not(.has-sidebar-page) {
       @include drawerWidth();
       @include drawerHeight();
-
       @media screen and (max-width: 2200px) {
         @include flatHeader();
         @include flatComposer();
         #reply-control {
-          width: calc(100vw - 400px);
-          max-width: var(--full-width-composer-max-width);
-          margin-left: auto;
-          margin-right: calc(var(--full-width-drawer-width) - 10px);
+          width: 100vw;
+          max-width: calc(100vw - var(--full-width-drawer-width));
+          margin-left: 0;
         }
       }
     }

--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -1,6 +1,3 @@
-<!--  This is a temporary override that modifies lines 33-43 to use "block:nearest"to
-avoid a problem with scrolling the main content -->
-
 <script type="text/discourse-plugin" version="0.8">
     const { cancel, schedule } = require("@ember/runloop");
     const { discourseLater } = require("discourse-common/lib/later");
@@ -30,6 +27,9 @@ avoid a problem with scrolling the main content -->
           return;
         }
 
+        // edited the below to avoid some chat bugs
+        // block: "nearest" avoids an issue where the body scrolls when chat does
+
         if (opts.highlight) {
           message.highlighted = true;
           if (this._selfDeleted) {
@@ -44,5 +44,35 @@ avoid a problem with scrolling the main content -->
         });
       });
     }
+  })
+
+  // below I get the width of the chat drawer and set it as a css variable
+  // so I can then set the right composer margin
+  // this is a little magic-numbery for now
+
+  const { action } = require("@ember/object");
+  const { observes } = require("discourse-common/utils/decorators");
+
+  api.modifyClass('component:chat-drawer', {
+    pluginId: "full-width-component",
+
+    @observes("chatStateManager.isDrawerActive")
+    _fireHiddenAppEvents() {
+      const chatDrawerSizeWidth = parseInt(localStorage.getItem('discourse_chat_drawer_size_width')) + 14 || 398 + 16;
+      if (chatDrawerSizeWidth) {
+        document.documentElement.style.setProperty('--custom-drawer-width-composer-margin', `${chatDrawerSizeWidth}px`);
+      }
+      this.appEvents.trigger("chat:rerender-header");
+    },
+
+    @action
+    didResize(element, { width, height }) {
+      console.log("resized")
+      this.chatDrawerSize.size = { width, height };
+      const composerMarginWidth = width + 14;
+      const clampedComposerMarginWidth = Math.min(Math.max(composerMarginWidth, 263), 652 );
+      document.documentElement.style.setProperty('--custom-drawer-width-composer-margin', `${clampedComposerMarginWidth}px`);
+    },
+
   })
 </script>


### PR DESCRIPTION
This takes the variable width of the chat drawer into consideration when restricting the composer width to avoid overlapping it.