### PR TITLE
UX: move composer so sidebar is visible on full-width large screens

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -140,7 +140,7 @@ body.has-sidebar-page {
   }
 
   @media screen and (min-width: $reply-area-max-width) {
-    #reply-control {
+    #reply-control.show-preview {
       max-width: calc(100vw - (100vw - 100%) - var(--d-sidebar-width) - 2rem);
       margin-right: 1rem;
     }

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -141,7 +141,7 @@ body.has-sidebar-page {
 
   @media screen and (min-width: $reply-area-max-width) {
     #reply-control {
-      max-width: calc(100vw - (100vw - 100%) - var(--d-sidebar-width) - 1rem);
+      max-width: calc(100vw - (100vw - 100%) - var(--d-sidebar-width) - 2rem);
       margin-right: 1rem;
     }
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -138,6 +138,17 @@ body.has-sidebar-page {
   .wrap {
     max-width: unset;
   }
+
+  @media screen and (min-width: $reply-area-max-width) {
+    #reply-control {
+      max-width: calc(100vw - (100vw - 100%) - var(--d-sidebar-width) - 1rem);
+      margin-right: 1rem;
+    }
+
+    .sidebar-container {
+      height: auto;
+    }
+  }
 }
 
 body.sidebar-animate {


### PR DESCRIPTION
Doesn't fix every possible scenario/layout, but the default full-width large screen with preview open looks better:

<img width="1654" alt="image" src="https://github.com/discourse/discourse-full-width-component/assets/101828855/dd5328e4-8412-4628-aafb-d187cd924109">


When the screen gets smaller it reverts back to the old way:
<img width="1290" alt="image" src="https://github.com/discourse/discourse-full-width-component/assets/101828855/191b430a-20e4-4c4d-9098-6eefb7f030c6">
