### PR TITLE
DEV: remove template override, add bootstrap mode

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -18,7 +18,6 @@
 
   body.has-sidebar-page & {
     grid-template-columns: 1fr minmax(0, var(--d-max-width)) 1fr; // overriding core
-
     .sidebar-wrapper {
       width: var(--d-sidebar-width);
     }
@@ -58,35 +57,55 @@
 }
 
 .d-header {
-  .header-contents__toggle-and-logo {
-    display: flex;
-    align-items: center;
-    min-width: 0;
-  }
   > .wrap {
     .contents {
       display: grid;
-      grid-template-areas: "toggle lspace extra-info rspace panel";
+      grid-template-areas: "logo lspace extra-info rspace panel";
       grid-template-columns:
-        calc(var(--d-sidebar-width) - 11px) // 11px is wrap padding
+        auto
         1fr
-        minmax(0, calc(var(--d-max-width) + 7.25em))
+        minmax(0, calc(var(--d-max-width) - 2em))
         1fr
         auto;
-      gap: 0;
+      .d-header-mode {
+        grid-area: lspace;
+        white-space: nowrap;
+        @include breakpoint("tablet") {
+          display: none;
+        }
+      }
 
       .has-sidebar-page & {
         grid-template-columns:
           calc(var(--d-sidebar-width) - 11px) // 11px is wrap padding
           1fr
-          minmax(0, calc(var(--d-max-width) + 7.25em))
+          minmax(0, calc(var(--d-max-width) + 7.15em))
           1fr
           auto;
         gap: 1em;
+        @media screen and (max-width: 1000px) {
+          gap: 0.5em;
+        }
+        .d-header-mode {
+          grid-area: extra-info;
+        }
       }
     }
   }
+  .header-sidebar-toggle {
+    grid-area: logo;
+  }
+  .before-header-panel-outlet {
+    grid-area: extra-info;
+  }
+  .d-header-mode {
+    .bootstrap-mode {
+      margin: 0;
+    }
+  }
   .title {
+    grid-area: logo;
+    margin-left: 3.7em; // 2.7em hamburger width + 1em for margin
     min-width: 0;
     margin-right: 0.725em;
     a {
@@ -98,45 +117,22 @@
   }
 }
 
-body:not(.has-sidebar-page) {
-  .d-header {
-    > .wrap {
-      .contents {
-        &.header-title-docked {
-          @media screen and (max-width: 1360px) {
-            grid-template-columns:
-              auto
-              1fr
-              minmax(0, calc(var(--d-max-width) + 7.25em))
-              1fr
-              auto;
-          }
-
-          grid-template-columns:
-            auto
-            1fr
-            minmax(0, calc(var(--d-max-width) + -0.9em))
-            // -.8em varies a little for logo vs home icon... consider making those the same size
-            1fr
-            auto;
-          gap: 0;
-        }
-      }
-    }
-  }
-}
-
 .extra-info-wrapper {
   grid-area: extra-info;
   max-width: var(--d-max-width);
   width: 100%;
   box-sizing: border-box;
-  padding-right: 0;
+  padding: 0;
 }
 
 body.has-sidebar-page {
   .wrap {
-    max-width: unset;
+    max-width: unset; // undoing core default
+  }
+
+  .d-header-mode,
+  .extra-info-wrapper {
+    padding: 0;
   }
 
   @media screen and (min-width: $reply-area-max-width) {

--- a/javascripts/discourse/api-initializers/full-width.js
+++ b/javascripts/discourse/api-initializers/full-width.js
@@ -1,35 +1,9 @@
 import { apiInitializer } from "discourse/lib/api";
-import hbs from "discourse/widgets/hbs-compiler";
 import Session from "discourse/models/session";
 import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 
 export default apiInitializer("0.8", (api) => {
-  api.reopenWidget("header-contents", {
-    tagName: "div.contents",
-
-    buildClasses(attrs) {
-      return attrs.minimized ? "header-title-docked" : "";
-    },
-
-    template: hbs`
-   
-      <div class="header-contents__toggle-and-logo" data-docked-title={{attrs.minimized}}>
-        {{#if this.site.desktopView}}
-          {{#if attrs.sidebarEnabled}}
-            {{sidebar-toggle attrs=attrs}}
-          {{/if}}
-        {{/if}}
-        {{home-logo attrs=attrs}}
-      </div>
-      {{#if attrs.topic}}
-        {{header-topic-info attrs=attrs}}
-      {{/if}}
-      
-      <div class="panel clearfix" role="navigation">{{yield}}</div>
-    `,
-  });
-
   api.reopenWidget("home-logo", {
     logo() {
       const { siteSettings } = this,


### PR DESCRIPTION
This removes the template override and gets the full-width layout working with CSS only.

Now this will work with bootstrap mode and the new plugin outlet `before-header-panel`