### PR TITLE
UX: more accurate title centering at wide widths

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -76,12 +76,27 @@
       }
 
       .has-sidebar-page & {
+        // at wide widths, when 1fr > 0
+        // we want the panel to be the same width as the logo
+        // this way we can get more accurate centering
         grid-template-columns:
           calc(var(--d-sidebar-width) - 11px) // 11px is wrap padding
           1fr
-          minmax(0, calc(var(--d-max-width) + 7.15em))
+          minmax(0, calc(var(--d-max-width)))
           1fr
-          auto;
+          minmax(0, calc(var(--d-sidebar-width) - 11px));
+
+        // at narrower widths, when 1fr = 0
+        // we can center without mataching the logo's width
+        // which allows the title to take up the remaining width
+        @media screen and (max-width: 1400px) {
+          grid-template-columns:
+            calc(var(--d-sidebar-width) - 11px)
+            1fr
+            minmax(0, calc(var(--d-max-width)))
+            1fr
+            auto;
+        }
         gap: 1em;
         @media screen and (max-width: 1000px) {
           gap: 0.5em;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -56,23 +56,34 @@
   }
 }
 
+.d-header .title:not(.title--minimized) {
+  // allowing overflow here isn't always ideal
+  // but works well enough most of the time
+  overflow: visible;
+}
+
 .d-header {
   > .wrap {
     .contents {
       display: grid;
       grid-template-areas: "logo lspace extra-info rspace panel";
       grid-template-columns:
+        minmax(auto, 1fr)
         auto
-        1fr
-        minmax(0, calc(var(--d-max-width) - 2em))
-        1fr
-        auto;
+        minmax(0, calc(var(--d-max-width)))
+        auto
+        minmax(auto, 1fr);
+
       .d-header-mode {
-        grid-area: lspace;
+        grid-area: extra-info;
         white-space: nowrap;
         @include breakpoint("tablet") {
           display: none;
         }
+      }
+
+      .d-header .title {
+        min-width: auto;
       }
 
       .has-sidebar-page & {
@@ -121,10 +132,9 @@
   .title {
     grid-area: logo;
     margin-left: 3.7em; // 2.7em hamburger width + 1em for margin
-    min-width: 0;
     margin-right: 0.725em;
     a {
-      min-width: 0;
+      flex: 1 0 auto;
     }
   }
   .panel {

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -77,7 +77,7 @@
 
       .has-sidebar-page & {
         // at wide widths, when 1fr > 0
-        // we want the panel to be the same width as the logo
+        // we want the panel to be the same width as the sidebar
         // this way we can get more accurate centering
         grid-template-columns:
           calc(var(--d-sidebar-width) - 11px) // 11px is wrap padding
@@ -87,7 +87,7 @@
           minmax(0, calc(var(--d-sidebar-width) - 11px));
 
         // at narrower widths, when 1fr = 0
-        // we can center without mataching the logo's width
+        // we can center without mataching the sidebar's width
         // which allows the title to take up the remaining width
         @media screen and (max-width: 1400px) {
           grid-template-columns:


### PR DESCRIPTION
This eliminates that 7.15em magic number, and allows for more reliable docked title centering (especially if header icons are added or removed) 