### PR TITLE
Give header section enough space

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -74,7 +74,7 @@ $sidebar-width: #{$sidebar_width}em;
         auto
         minmax(0, calc(var(--d-max-width)))
         auto
-        minmax(auto, 1fr);
+        auto;
 
       .d-header-mode {
         grid-area: extra-info;


### PR DESCRIPTION
The panel section was sometimes getting smushed or pushed off screen due to it having a max of 1fr in the grid.

On try.discourse
<img width="1727" alt="image" src="https://github.com/discourse/discourse-full-width-component/assets/101828855/14056aef-8943-4c6a-8b77-8d82aa4c1bbf">

on the meta branded theme
<img width="918" alt="image" src="https://github.com/discourse/discourse-full-width-component/assets/101828855/7eae7768-7317-49e8-8d98-9aa6b762dc46">

Giving the panel section a width of auto fixes it.