### PR TITLE
UX: prevent logo from being hidden at narrow widths

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -135,7 +135,9 @@ $sidebar-width: #{$sidebar_width}em;
     grid-area: logo;
     margin-left: 3.7em; // 2.7em hamburger width + 1em for margin
     margin-right: 0.725em;
-    a {
+    display: flex;
+    overflow: visible;
+    .title {
       flex: 1 0 auto;
     }
   }


### PR DESCRIPTION
This fixes an issue where when the sidebar is collapsed, the logo can be hidden at narrow widths. 


Before:
![image](https://github.com/discourse/discourse-full-width-component/assets/1681963/d6b6406a-6e6f-42b8-892a-772b3287e709)


After: 
![image](https://github.com/discourse/discourse-full-width-component/assets/1681963/b582763c-262a-4772-8825-efe7af5d20c4)
