### PR TITLE
FIX: Use transformer for forcing large header logo

### DIFF
--- a/javascripts/discourse/api-initializers/full-width.gjs
+++ b/javascripts/discourse/api-initializers/full-width.gjs
@@ -6,8 +6,22 @@ export default apiInitializer("0.8", (api) => {
   document.body.classList.add("full-width-enabled");
 
   // When the sidebar is visible, force the HomeLogo to be in an 'un-minimized' state.
-  // Importing and using the HomeLogo component here isn't ideal... it's not really public API.
-  // But, it is certainly better than monkey-patching inside the component.
+  const transformerExists = api.registerValueTransformer?.(
+    "home-logo-minimized",
+    ({ value, context }) => {
+      if (value && context.showSidebar) {
+        return false;
+      }
+      return value;
+    }
+  );
+
+  if (transformerExists) {
+    return;
+  }
+
+  // Remove this fallback once the `home-logo-minimized` transformer is in
+  // stable
   api.renderInOutlet(
     "home-logo",
     class FullWidthHomeLogo extends Component {


### PR DESCRIPTION
Using a transformer is more reliable and less intrusive than using a plugin outlet to replace a chunk of a core template. The `home-logo-minimized` transformer is a recent addition to core (added in https://github.com/discourse/discourse/pull/30832), however this change is fully backward compatible -- if a site doesn't have the `registerValueTransformer` API or the new transformer, it will fallback to the plugin outlet override.