### PR TITLE
DEV: improve compatibility with header theme components

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -120,7 +120,7 @@ $sidebar-width: #{$sidebar_width}em;
           1fr
           minmax(0, calc(var(--d-max-width)))
           1fr
-          minmax(0, calc(var(--d-sidebar-width) - 11px));
+          auto;
         gap: 1em;
 
         // at narrower widths, when 1fr = 0
@@ -174,6 +174,7 @@ $sidebar-width: #{$sidebar_width}em;
 
   .panel {
     grid-area: panel;
+    justify-content: end;
   }
 }
 
@@ -263,11 +264,16 @@ body.sidebar-animate {
   }
 }
 
-// provides some extra space for login buttons
-@media screen and (width >= 1400px) {
-  .anon {
-    .d-header .panel {
-      grid-column-start: -4;
-    }
+// truncate button text rather than cause the entire header to overflow
+.d-header .header-buttons,
+.auth-buttons {
+  min-width: 0;
+}
+
+.auth-buttons button {
+  min-width: 0;
+
+  .d-button-label {
+    @include ellipsis;
   }
 }


### PR DESCRIPTION
This should improve the compatibility with other theme components, and specifically fixes this issue with custom header links... 

Before:
<img width="3020" height="164" alt="image" src="https://github.com/user-attachments/assets/d0a60d9b-4a3f-4789-835d-a992ddc4baef" />


After:
<img width="3024" height="166" alt="image" src="https://github.com/user-attachments/assets/77871851-6430-4787-9f31-23079891fe84" />


Previously the component moved the login buttons to provide more space for them, but this is a bit problematic and it's better to limit potential button overflow instead. 